### PR TITLE
Add contract version to the project properties

### DIFF
--- a/src/main/java/net/stickycode/plugin/shifty/ShiftyFetchMojo.java
+++ b/src/main/java/net/stickycode/plugin/shifty/ShiftyFetchMojo.java
@@ -140,6 +140,7 @@ public class ShiftyFetchMojo
     Version version = highestVersion(artifact);
     String propertyName = artifact.getArtifactId() + ".version";
     getProjectProperties().setProperty(propertyName, version.toString());
+    setContractVersion(getProjectProperties(), artifact, version);
     log("resolved %s to %s", artifact, version.toString());
 
     DefaultArtifact fetch = new DefaultArtifact(
@@ -149,6 +150,11 @@ public class ShiftyFetchMojo
       artifact.getExtension(),
       version.toString());
     return new ArtifactRequest(fetch, repositories, null);
+  }
+
+  private void setContractVersion(Properties projectProperties, DefaultArtifact artifact, Version version) {
+    String v = version.toString();
+    projectProperties.setProperty(artifact.getArtifactId() + ".contractVersion", v.substring(0, v.indexOf('.')));
   }
 
   Properties getProjectProperties() {

--- a/src/main/java/net/stickycode/plugin/shifty/ShiftyFetchMojo.java
+++ b/src/main/java/net/stickycode/plugin/shifty/ShiftyFetchMojo.java
@@ -154,7 +154,11 @@ public class ShiftyFetchMojo
 
   private void setContractVersion(Properties projectProperties, DefaultArtifact artifact, Version version) {
     String v = version.toString();
-    projectProperties.setProperty(artifact.getArtifactId() + ".contractVersion", v.substring(0, v.indexOf('.')));
+    int index = v.indexOf('.');
+    if (index == -1)
+      projectProperties.setProperty(artifact.getArtifactId() + ".contractVersion", v);
+    else
+      projectProperties.setProperty(artifact.getArtifactId() + ".contractVersion", v.substring(0, index));
   }
 
   Properties getProjectProperties() {

--- a/src/test/java/net/stickycode/plugin/shifty/ShiftyFetchMojoComponentTest.java
+++ b/src/test/java/net/stickycode/plugin/shifty/ShiftyFetchMojoComponentTest.java
@@ -71,6 +71,14 @@ public class ShiftyFetchMojoComponentTest {
     assertThat(mojo.getProjectProperties().get("example.contractVersion")).isEqualTo("1");
   }
 
+  @Test
+  public void checkSetPropertiesWithSingleVersion() {
+    ShiftyFetchMojo mojo = mojo(true, true, null, "1");
+    mojo.findArtifact(new DefaultArtifact("com.example:example:[1,2)")).getArtifact();
+    assertThat(mojo.getProjectProperties().get("example.version")).isEqualTo("1");
+    assertThat(mojo.getProjectProperties().get("example.contractVersion")).isEqualTo("1");
+  }
+
   private void checkSnapshots(String givenVersion, String expectation, String... resolvedVersions) {
     check(false, false, givenVersion, expectation, null, resolvedVersions);
   }

--- a/src/test/java/net/stickycode/plugin/shifty/ShiftyFetchMojoComponentTest.java
+++ b/src/test/java/net/stickycode/plugin/shifty/ShiftyFetchMojoComponentTest.java
@@ -63,6 +63,14 @@ public class ShiftyFetchMojoComponentTest {
     checkNoSnapshots("[5.6]", "5.6", "5.9", "5.6", "6.5", "6.10");
   }
 
+  @Test
+  public void checkSetProperties() {
+    ShiftyFetchMojo mojo = mojo(true, true, null, "1.2");
+    mojo.findArtifact(new DefaultArtifact("com.example:example:[1,2)")).getArtifact();
+    assertThat(mojo.getProjectProperties().get("example.version")).isEqualTo("1.2");
+    assertThat(mojo.getProjectProperties().get("example.contractVersion")).isEqualTo("1");
+  }
+
   private void checkSnapshots(String givenVersion, String expectation, String... resolvedVersions) {
     check(false, false, givenVersion, expectation, null, resolvedVersions);
   }
@@ -78,7 +86,15 @@ public class ShiftyFetchMojoComponentTest {
   private void check(boolean ignoreSnapshots, boolean assumingSnapshotsAreLocal, String givenVersion, String expectation,
       Exception exception,
       String... resolvedVersions) {
+    ShiftyFetchMojo mojo = mojo(ignoreSnapshots, assumingSnapshotsAreLocal, exception, resolvedVersions);
+    Artifact artifact = mojo.findArtifact(new DefaultArtifact("com.example:example:" + givenVersion)).getArtifact();
+    assertThat(artifact.getVersion()).isEqualTo(expectation);
+  }
+
+  private ShiftyFetchMojo mojo(boolean ignoreSnapshots, boolean assumingSnapshotsAreLocal, Exception exception,
+      String... resolvedVersions) {
     ShiftyFetchMojo mojo = new ShiftyFetchMojo() {
+      Properties p = new Properties();
 
       @Override
       VersionRangeResult resolveRangeRequest(VersionRangeRequest request) {
@@ -95,7 +111,7 @@ public class ShiftyFetchMojoComponentTest {
 
       @Override
       Properties getProjectProperties() {
-        return new Properties();
+        return p;
       }
 
       @Override
@@ -108,8 +124,7 @@ public class ShiftyFetchMojoComponentTest {
         return ignoreSnapshots;
       }
     };
-    Artifact artifact = mojo.findArtifact(new DefaultArtifact("com.example:example:" + givenVersion)).getArtifact();
-    assertThat(artifact.getVersion()).isEqualTo(expectation);
+    return mojo;
   }
 
 }


### PR DESCRIPTION
- Adding a contract version to the project properties
- Allow the resolve version to have only one component
