### PR TITLE
Put maven deps into provided scope so 3.9.2 is happier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-embedder</artifactId>
-      <version>[3.6.3]</version>
+      <version>[3.9.2]</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -63,12 +63,14 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>[3.6.3]</version>
+      <version>[3.9.2]</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
-      <version>[3.6.3]</version>
+      <version>[3.9.2]</version>
+      <scope>provided</scope>
     </dependency>
 
   </dependencies>
@@ -78,7 +80,7 @@
       <plugin>
         <groupId>io.repaint.maven</groupId>
         <artifactId>tiles-maven-plugin</artifactId>
-        <version>2.29</version>
+        <version>2.34</version>
         <configuration>
           <tiles>
             <tile>net.stickycode.tile:sticky-tile-release:[2,3)</tile>
@@ -87,14 +89,14 @@
       </plugin>
       <plugin>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>3.9.0</version>
         <configuration>
           <goalPrefix>shifty</goalPrefix>
         </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-invoker-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.5.1</version>
         <configuration>
           <projectsDirectory>src/it</projectsDirectory>
           <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   </scm>
 
   <prerequisites>
-    <maven>3.6.0</maven>
+    <maven>3.6.3</maven>
   </prerequisites>
 
 
@@ -37,9 +37,10 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-embedder</artifactId>
-      <version>[3.9.2]</version>
+      <version>[3.6.3]</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>net.stickycode.composite</groupId>
       <artifactId>sticky-composite-unittest</artifactId>
@@ -63,13 +64,14 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>[3.9.2]</version>
+      <version>[3.6.3]</version>
       <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
-      <version>[3.9.2]</version>
+      <version>[3.6.3]</version>
       <scope>provided</scope>
     </dependency>
 


### PR DESCRIPTION
- Use provided scope to allow maven 3.9.2 to not complain
- Lets standardise on 3.8.1 as a lower bound
